### PR TITLE
 Passing Wrong data as location

### DIFF
--- a/deployment/weather-configmap.yaml
+++ b/deployment/weather-configmap.yaml
@@ -10,4 +10,4 @@ data:
 
       data:
         url: "https://api.data.gov.sg/v1/environment/rainfall"
-        location: ""
+        location: "sunglade"


### PR DESCRIPTION
Passing "Sunglade as Location " where Sunglade is not present in API.